### PR TITLE
[fix] docker container to have correct version of reachy package

### DIFF
--- a/software/reachy-docker/Dockerfile
+++ b/software/reachy-docker/Dockerfile
@@ -1,33 +1,26 @@
-FROM ubuntu:18.04
-LABEL maintainer="phillipcchin@gmail.com"
+# this docker fixes a issue with the existing docker container 
+# where there was a compatibitly issue with reachy 1.2.3 with the pylous module 
+# fix was the  grading the version to reachy 1.3.2 
+# pip install reachy==1.3.2 
+FROM ekkus93/reachy-docker:latest
+LABEL maintainer="oranbusiness@gmail.com"
+# activate the prebuild conda python enviorment so pip  correctly installs
+# in the right place
+# SHELL ["/bin/bash", "--login", "-c"]
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install wget screen bzip2 curl -y
+# # conda requires shell to be initalized to run conda commands
+# # SHELL ["conda", "init", "reachy-env","&&","pip","uninstall","reachy","&&","pip","uninstall","reachy","/bin/bash", "-c"]
+# # remove the existing reachy package
+# RUN pip uninstall reachy
+# # install the fixed and correct version number
+# RUN pip install reachy==1.3.2
 
-RUN apt-get install build-essential -y
-RUN apt-get install emacs -y
+COPY environment.yml .
+# RUN conda env create -f environment.yml
+RUN conda env update --file environment.yml
+# Make RUN commands use the new environment:
+SHELL ["conda", "run", "-n", "reachy-env", "/bin/bash", "-c"]
 
-RUN apt-get install libpulse-dev libasound2-dev pavucontrol -y
-
-# Anaconda
-# COPY ./Anaconda3-2020.07-Linux-x86_64.sh /tmp/
-RUN curl https://repo.anaconda.com/archive/Anaconda3-2020.07-Linux-x86_64.sh -s -o /tmp/Anaconda3-2020.07-Linux-x86_64.sh
-RUN cd /tmp && bash ./Anaconda3-2020.07-Linux-x86_64.sh -b -p /opt/anaconda && rm Anaconda3-2020.07-Linux-x86_64.sh
-RUN /opt/anaconda/bin/conda update -n base conda
-RUN /opt/anaconda/bin/conda install pip
-RUN /opt/anaconda/bin/pip install --upgrade pip
-
-COPY environment.yml /tmp
-RUN cd /tmp && /opt/anaconda/bin/conda env create -f environment.yml && rm environment.yml
-ENV PATH /opt/anaconda/bin:$PATH
-
-SHELL ["/bin/bash", "-c"]
-
-RUN echo "source activate reachy-docker" >> ~root/.bashrc
-
-ENV TERM xterm-256color
-VOLUME ["/reachy"]
-
-COPY ./run.sh /tmp
-RUN chmod ugo+x /tmp/run.sh
-CMD ["/tmp/run.sh"]
+# Make sure the environment is activated:
+RUN echo "Make sure flask is installed:"
+RUN python -c "import reachy"

--- a/software/reachy-docker/__ARCHIVE__/Dockerfile.old
+++ b/software/reachy-docker/__ARCHIVE__/Dockerfile.old
@@ -1,0 +1,33 @@
+FROM ubuntu:18.04
+LABEL maintainer="oranbusiness@gmail.com"
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install wget screen bzip2 curl -y
+
+RUN apt-get install build-essential -y
+RUN apt-get install emacs -y
+
+RUN apt-get install libpulse-dev libasound2-dev pavucontrol -y
+
+# Anaconda
+# COPY ./Anaconda3-2020.07-Linux-x86_64.sh /tmp/
+RUN curl https://repo.anaconda.com/archive/Anaconda3-2020.07-Linux-x86_64.sh -s -o /tmp/Anaconda3-2020.07-Linux-x86_64.sh
+RUN cd /tmp && bash ./Anaconda3-2020.07-Linux-x86_64.sh -b -p /opt/anaconda && rm Anaconda3-2020.07-Linux-x86_64.sh
+RUN /opt/anaconda/bin/conda update -n base conda
+RUN /opt/anaconda/bin/conda install pip
+RUN /opt/anaconda/bin/pip install --upgrade pip
+
+COPY environment.yml /tmp
+RUN cd /tmp && /opt/anaconda/bin/conda env create -f environment.yml && rm environment.yml
+ENV PATH /opt/anaconda/bin:$PATH
+
+SHELL ["/bin/bash", "-c"]
+
+RUN echo "source activate reachy-docker" >> ~root/.bashrc
+
+ENV TERM xterm-256color
+VOLUME ["/reachy"]
+
+COPY ./run.sh /tmp
+RUN chmod ugo+x /tmp/run.sh
+CMD ["/tmp/run.sh"]

--- a/software/reachy-docker/__ARCHIVE__/docker-compose.old.yml
+++ b/software/reachy-docker/__ARCHIVE__/docker-compose.old.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     reachy-docker:
-        image: wisehackermonkey/reachy-docker:latest
+        image: ekkus93/reachy-docker:latest
         container_name: reachy-docker
         ports:
             - 8888:8888

--- a/software/reachy-docker/environment.yml
+++ b/software/reachy-docker/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - pyaudio
     - swig
     - pip:
-        - reachy==1.2.3
+        - reachy==1.3.2
         - paho-mqtt
         - webrtcvad
         - pocketsphinx


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29699356/105272425-27e7a000-5b4e-11eb-98a1-fbdecbeeb820.png)
![image](https://user-images.githubusercontent.com/29699356/105272428-2918cd00-5b4e-11eb-9dce-7e845df87e14.png)
FIXED BUG:

updated python library 'reachy" from 1.2.3 → 1.3.2, this fixed the issue where it says 'pyluos not found'